### PR TITLE
Fix DIND to make the images more reusable

### DIFF
--- a/images/10-dind.conf
+++ b/images/10-dind.conf
@@ -1,0 +1,10 @@
+[Service]
+# From Docker's dind script:
+# apparmor sucks and Docker needs to know that it's in a container (c) @tianon
+Environment=container=docker
+# See https://github.com/kubernetes/release/pull/86#issuecomment-248185616
+# Default storage to vfs to avoid using loopback. Slower, but if volumes
+# aren't unmounted cleanly loopback devices can be leaked, and once
+# exhuasted the only fix is to restart the host.
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=vfs $DOCKER_EXTRA_OPTS

--- a/images/build-debian.sh
+++ b/images/build-debian.sh
@@ -53,3 +53,6 @@ apt-get -qq -y autoremove
 apt-get -qq clean
 
 ls /var/lib/apt/lists/* /tmp/* /var/tmp/* | remove_files
+
+chmod +x /usr/sbin/dind_prepare
+systemctl enable dind_prepare

--- a/images/dind_prepare
+++ b/images/dind_prepare
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Based on https://github.com/docker/docker/blob/master/hack/dind
+# Copyright 2012-2016 Docker, Inc.
+# Original version by Jerome Petazzoni <jerome@docker.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Ensure shared mount propagation to ensure volume mounting works for Kubernetes.
+# Took it from here:
+# https://github.com/marun/dkr-systemd-dind/blob/25702cf7a4a73bcc355a492f4e5ca96cc562a5a5/dind-setup.sh#L46
+mount --make-shared /
+
+# securityfs is mounted by systemd itself if it isn't being run in a container.
+# In case of containerized systemd, it doesn't want to have systemd mounted
+# on startup because it wants to avoid dealing with IMA in this case.
+# See https://github.com/systemd/systemd/blob/master/src/shared/ima-util.c
+# IMA stands for Integrity Measurement Architecture
+# https://sourceforge.net/p/linux-ima/wiki/Home/#integrity-measurement-architecture-ima
+# Still, we need to have securityfs in DIND for AppArmor detection and
+# support for --privileged mode, so we're mounting it there.
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+  mount -t securityfs none /sys/kernel/security || {
+    echo >&2 'Could not mount /sys/kernel/security.'
+    echo >&2 'AppArmor detection and --privileged mode might break.'
+  }
+fi
+
+# Mount /tmp (conditionally)
+if ! mountpoint -q /tmp; then
+  mount -t tmpfs none /tmp
+fi

--- a/images/dind_prepare.service
+++ b/images/dind_prepare.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Prepare to start docker-in-docker
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/dind_prepare
+
+[Install]
+RequiredBy=docker.service

--- a/images/xenial-systemd-bare.dkr
+++ b/images/xenial-systemd-bare.dkr
@@ -18,6 +18,8 @@
 
 FROM ubuntu:xenial
 
+# http://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/
+# SIGRTMIN+3 is the shutdown signal for systemd
 STOPSIGNAL SIGRTMIN+3
 
 CMD [ "/sbin/init" ]

--- a/images/xenial-systemd-bare.dkr
+++ b/images/xenial-systemd-bare.dkr
@@ -22,4 +22,10 @@ FROM ubuntu:xenial
 # SIGRTMIN+3 is the shutdown signal for systemd
 STOPSIGNAL SIGRTMIN+3
 
-CMD [ "/sbin/init" ]
+# See https://github.com/kubernetes/release/pull/86#issuecomment-248185616
+# Hardlink init to another name to avoid having oci-systemd-hooks (rhel/fedora/centos)
+# detect containers using this image as requiring read-only cgroup
+# mounts.  dind containers are intended to be run with --privileged
+# to ensure cgroups mounted with read-write permissions.
+RUN ln /sbin/init /sbin/dind_init
+ENTRYPOINT ["/sbin/dind_init"]

--- a/images/xenial-systemd-base.dkr
+++ b/images/xenial-systemd-base.dkr
@@ -1,3 +1,6 @@
 FROM gcr.io/kubeadm/ci-xenial-systemd:bare
-ADD ./build-debian.sh /tmp/build.sh
+COPY ./build-debian.sh /tmp/build.sh
+COPY ./10-dind.conf /etc/systemd/system/docker.service.d/
+COPY ./dind_prepare /usr/sbin/
+COPY ./dind_prepare.service /lib/systemd/system/
 RUN /tmp/build.sh


### PR DESCRIPTION
1. Add a comment about `STOPSIGNAL SIGRTMIN+3` in xenial-systemd-bare.dkr
2. Force Docker to use VFS driver. It'll default to devicemapper otherwise which doesn't always work & may cause problems with loop device exhaustion
3. Add dind script based on Docker's own dind setup. Added `mount --make-shared /` there because otherwise there may be problems with volume mounts [according](https://github.com/marun/dkr-systemd-dind/blob/25702cf7a4a73bcc355a492f4e5ca96cc562a5a5/dind-setup.sh#L46) to @marun
